### PR TITLE
Bug fix when name forced by owner

### DIFF
--- a/src/modules/profile.ts
+++ b/src/modules/profile.ts
@@ -348,6 +348,7 @@ export class ProfileModule extends Module
                 C?.IsGagged()
                 || !Player.IsDeaf()
                 || PlayerP().petHearing === false
+                || !text
             )
             {
                 return next([text, intensity, ignoreOOC]);

--- a/src/util/petHearAndSpeak.ts
+++ b/src/util/petHearAndSpeak.ts
@@ -31,6 +31,15 @@ export function ApplyPetHearing([text, intensity, ignoreOOC]: [string, number, b
     next: (args: [text: string, intensity: number, ignoreOOC?: boolean | undefined]) => string,
     phrasesToKeep: string[]): string
 {
+    // Error correction because uhhhhh why??? Idk cuz string is not a string, its undefined
+    if (!text
+        || isNaN(intensity)
+        || !(typeof ignoreOOC == "boolean" || typeof ignoreOOC == "undefined") 
+    )
+    {
+        return next([text, intensity, ignoreOOC]);
+    }
+
     // Split the input text into different substrings exluding the words you want to keep
     // Step 1: Get the words you want to keep if any
     // const phrasesToKeep = GetPetHearingPhrases();


### PR DESCRIPTION
For some reason text is set to undefined when ear-plugged, blind, and name force set by owner when it should be string