### PR TITLE
FEAT: Statistic tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"devDependencies": {
 		"@eslint/js": "^9.9.0",
 		"@stylistic/eslint-plugin": "^2.6.2",
-		"bc-stubs": "^111.0.0",
+		"bc-stubs": "^115.0.1",
 		"eslint": "^9.9.0",
 		"globals": "^15.9.0",
 		"lz-string": "^1.5.0",

--- a/src/localization/template.json
+++ b/src/localization/template.json
@@ -139,5 +139,10 @@
     "SourceCharacter stomps PronounPossessive hoof on the ground twice.":"",
 
     "SourceCharacter crawls into PronounPossessive bed.":"",
-    "SourceCharacter tucks TargetCharacter into bed.":""
+    "SourceCharacter tucks TargetCharacter into bed.":"",
+
+    "Water": "",
+    "Food": "",
+    "Sleep": "",
+    "Affection": ""
 }

--- a/src/modules/settings.ts
+++ b/src/modules/settings.ts
@@ -116,8 +116,6 @@ export let currentMenu: ModuleTitle | null | "RESET_Settings" = null;
 let settingsOpen: boolean = false;
 let allowResetTime: number = 0;
 
-DrawButton(1520, 720, 200, 80, "Cancel", "White");
-
 function DrawMenuOptions(menuOptions: string[]): void
 {
     for (let i = 0; i < menuOptions.length; i++)

--- a/src/modules/virtualPetHUD.ts
+++ b/src/modules/virtualPetHUD.ts
@@ -65,7 +65,8 @@ function DrawStatCircle(x: number, y: number, radius: number, stat: VirtualPetSt
 
 function DrawStatTooltip(x: number, y: number, radius: number, stat: VirtualPetStat)
 {
-    const tootipText = LocalizedText(stat.stat.charAt(0).toUpperCase() + stat.stat.slice(1));
+    const statName = LocalizedText(stat.stat.charAt(0).toUpperCase() + stat.stat.slice(1));
+    const tootipText = `${statName}: ${Math.round(stat.level * 100)}%`;
 
     if (MouseIn(x - radius, y - radius, radius * 2, radius * 2))
     {

--- a/src/modules/virtualPetHUD.ts
+++ b/src/modules/virtualPetHUD.ts
@@ -56,8 +56,15 @@ function DrawStatCircle(x: number, y: number, radius: number, stat: VirtualPetSt
     if (PlayerVPHUD().exactStats)
     {
         const prevFont = MainCanvas.font;
-        MainCanvas.fillStyle = "#000000";
         MainCanvas.font = CommonGetFont(radius * 1.25);
+        
+        // Set up outline
+        MainCanvas.lineWidth = 2; // adjust as needed
+        MainCanvas.strokeStyle = "#000000";
+        MainCanvas.strokeText(Math.round(stat.level * 100).toString(), x, y + (radius * 0.125));
+
+        // Fill the text
+        MainCanvas.fillStyle = "#ffffff"; // or any fill color you want
         MainCanvas.fillText(Math.round(stat.level * 100).toString(), x, y + (radius * 0.125));
         MainCanvas.font = prevFont;
     }

--- a/src/modules/virtualPetHUD.ts
+++ b/src/modules/virtualPetHUD.ts
@@ -2,6 +2,7 @@ import { HookFunction } from "../util/sdk";
 import { IsMemberNumberInAuthGroup } from "../util/authority";
 import { Module, ModuleTitle } from "./_module";
 import { GetCharacterCurrentStatValue, VirtualPetStatCategory, type VirtualPetStat } from "./virtualPet";
+import { LocalizedText } from "../localization/localization";
 
 const PlayerVP: () => MPARecord = () =>
 {
@@ -54,28 +55,85 @@ function DrawStatCircle(x: number, y: number, radius: number, stat: VirtualPetSt
     // Display the text
     if (PlayerVPHUD().exactStats)
     {
+        const prevFont = MainCanvas.font;
         MainCanvas.fillStyle = "#000000";
         MainCanvas.font = CommonGetFont(radius * 1.25);
         MainCanvas.fillText(Math.round(stat.level * 100).toString(), x, y + (radius * 0.125));
-        // Default size, idk if needed but can't hurt
-        MainCanvas.font = CommonGetFont(36);
+        MainCanvas.font = prevFont;
+    }
+}
+
+function DrawStatTooltip(x: number, y: number, radius: number, stat: VirtualPetStat)
+{
+    const tootipText = LocalizedText(stat.stat.charAt(0).toUpperCase() + stat.stat.slice(1));
+
+    if (MouseIn(x - radius, y - radius, radius * 2, radius * 2))
+    {
+        const prevTextAlign = MainCanvas.textAlign;
+        const prevFont = MainCanvas.font;
+
+        MainCanvas.textAlign = "left";
+        MainCanvas.font = CommonGetFont(26);
+
+        const pad = 5;
+        const pos: "Left" | "Center" | "Right" | "Split" = PlayerVPHUD().position;
+        const size = MainCanvas.measureText(tootipText);
+        const width = size.actualBoundingBoxRight - size.actualBoundingBoxLeft + 2 * pad;
+        const height = size.actualBoundingBoxDescent + size.actualBoundingBoxAscent + 2 * pad;
+
+        let TextX = x;
+        let TextY = y;
+
+        // Adjust position based on HUD position
+        switch (pos)
+        {
+            case "Left":
+                TextX = x + pad;
+                break;
+            case "Center":
+            case "Split":
+                TextX = x - width / 2;
+                TextY = TextY - height;
+                break;
+            case "Right":
+                TextX = x - width;
+                break;
+        }
+
+        TextY = TextY - size.actualBoundingBoxAscent;
+
+        DrawRect(TextX - pad + 3, TextY - pad + 3, width, height, "rgba(0, 0, 0, .7)");
+        DrawRect(TextX - pad, TextY - pad, width, height, "#D7F6E9");
+        DrawTextFit(tootipText, TextX, TextY + pad * 2, size.width, "Black");
+
+        MainCanvas.textAlign = prevTextAlign;
+        MainCanvas.font = prevFont;
     }
 }
 
 function DrawVirualPetHud(x: number, y: number, zoom: number, stats: VirtualPetStat[]): void
 {
     const pos: "Left" | "Center" | "Right" | "Split" = PlayerVPHUD().position;
+
+    type PositionedStat = {
+        stat: VirtualPetStat;
+        x: number;
+        y: number;
+    };
+
+    const circles: PositionedStat[] = [];
+
     if (pos === "Left" || pos === "Right")
     {
-        stats.reverse();
-        stats.forEach((stat, index) =>
+        const baseX = x + (pos === "Left" ? 80 : 420) * zoom;
+        const reversedStats = [...stats].reverse();
+        reversedStats.forEach((stat, index) =>
         {
-            DrawStatCircle(
-                x + ((pos === "Left" ? 80 : 420) * zoom),
-                y + (950 - (index * 36)) * zoom,
-                16 * zoom,
-                stat
-            );
+            circles.push({
+                stat: stat,
+                x: baseX,
+                y: y + (950 - (index * 36)) * zoom
+            });
         });
     }
     else if (pos === "Center")
@@ -83,12 +141,11 @@ function DrawVirualPetHud(x: number, y: number, zoom: number, stats: VirtualPetS
         const statLen = stats.length;
         stats.forEach((stat, index) =>
         {
-            DrawStatCircle(
-                x + (250 - ((statLen - 1) * 18) + (index * 36)) * zoom,
-                y + (950 * zoom),
-                16 * zoom,
-                stat
-            );
+            circles.push({
+                stat: stat,
+                x: x + (250 - ((statLen - 1) * 18) + (index * 36)) * zoom,
+                y: y + (950 * zoom)
+            });
         });
     }
     // Probably a better way to do this, but I don't care. It works thats all I need.
@@ -97,37 +154,37 @@ function DrawVirualPetHud(x: number, y: number, zoom: number, stats: VirtualPetS
         const cols: VirtualPetStat[][] = [];
         switch (stats.length)
         {
-            case 1:
-                cols.push([stats[0]]);
-                cols.push([]);
-                break;
-            case 2:
-                cols.push([stats[0]]);
-                cols.push([stats[1]]);
-                break;
-            case 3:
-                cols.push([stats[1], stats[0]]);
-                cols.push([stats[2]]);
-                break;
-            case 4:
-                cols.push([stats[1], stats[0]]);
-                cols.push([stats[3], stats[2]]);
-                break;
+            case 1: cols.push([stats[0]], []); break;
+            case 2: cols.push([stats[0]], [stats[1]]); break;
+            case 3: cols.push([stats[1], stats[0]], [stats[2]]); break;
+            case 4: cols.push([stats[1], stats[0]], [stats[3], stats[2]]); break;
             default:
         }
-        cols.forEach((col, index) =>
+        cols.forEach((col, colIndex) =>
         {
+            const baseX = x + (colIndex === 0 ? 80 : 420) * zoom;
             col.forEach((stat, statIndex) =>
             {
-                DrawStatCircle(
-                    x + ((index == 0 ? 80 : 420) * zoom),
-                    y + (950 - (statIndex * 36)) * zoom,
-                    16 * zoom,
-                    stat
-                );
+                circles.push({
+                    stat: stat,
+                    x: baseX,
+                    y: y + (950 - statIndex * 36) * zoom
+                });
             });
         });
     }
+
+    // Draw all circles
+    circles.forEach(({ stat, x, y }) =>
+    {
+        DrawStatCircle(x, y, 16 * zoom, stat);
+    });
+
+    // Draw all tooltips after
+    circles.forEach(({ stat, x, y }) =>
+    {
+        DrawStatTooltip(x, y, 16 * zoom, stat);
+    });
 }
 
 function ShouldDrawHud<T extends typeof DrawArousalMeter | typeof DrawCharacter>(

--- a/src/util/sdk.ts
+++ b/src/util/sdk.ts
@@ -62,7 +62,7 @@ export function RemoveHooks(module: ModuleTitle | null): void
  */
 export async function AwaitPlayer(): Promise<void>
 {
-    if (Player.MemberNumber && Player.ExtensionSettings)
+    if (Player?.MemberNumber && Player?.ExtensionSettings)
     {
         return;
     }


### PR DESCRIPTION
Adds tooltips to statistic circles when you hover over them. Shows statistic's name and its level.
Adds subtle outline for numbers inside circles and changes color to white for better readability. 
![image](https://github.com/user-attachments/assets/75f285ec-e2e9-4792-a27e-3eeed3697929)
![image](https://github.com/user-attachments/assets/e919af1e-1e28-42b2-be6b-1b8312d4e0d9)
![image](https://github.com/user-attachments/assets/7b683eb1-e39f-4d2b-82a2-51189de5ac90)
![image](https://github.com/user-attachments/assets/a3104818-eb6f-49d1-a375-1a0f6db66e8c)
![image](https://github.com/user-attachments/assets/713c9047-163e-4cf8-aef4-23b196b02107)

As a bonus it fixes two crashes when mod loads.
